### PR TITLE
Update `glib` to resolve security advisory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "javascriptcore"
 
 [dependencies]
 bitflags = "^1.0"
-glib = "^0.18.0"
+glib = "^0.20.0"
 
   [dependencies.ffi]
   package = "javascriptcore-rs-sys"


### PR DESCRIPTION
There's an advisory on the `glib` version that this crate depends on: https://github.com/advisories/GHSA-wrw7-89jp-8q8g

closes #84 

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix: fix incorrect generated type
    - docs: update docstrings
    - feat: update bindings

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/javascriptcore-s/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->
