### PR TITLE
chore: update bitflags dependency version to 2.0

### DIFF
--- a/.changes/update-bitflags-to-2-0.md
+++ b/.changes/update-bitflags-to-2-0.md
@@ -1,0 +1,7 @@
+---
+"javascriptcore-rs": patch
+---
+
+Update bitflags dependency version to 2.0.
+
+This avoids duplicated dependencies in downstream crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = [ "--cfg", "docsrs" ]
 name = "javascriptcore"
 
 [dependencies]
-bitflags = "^1.0"
+bitflags = "^2.0"
 glib = "^0.18.0"
 
   [dependencies.ffi]


### PR DESCRIPTION
This avoids duplicated dependencies in downstream crates.